### PR TITLE
Block sparql console

### DIFF
--- a/askomics/api/sparql.py
+++ b/askomics/api/sparql.py
@@ -12,7 +12,7 @@ sparql_bp = Blueprint('sparql', __name__, url_prefix='/')
 
 
 def can_access(user):
-    login_allowed = current_app.iniconfig.get('askomics', 'enable_sparql_console', fallback=False)
+    login_allowed = current_app.iniconfig.getboolean('askomics', 'enable_sparql_console', fallback=False)
     return login_allowed or user['admin']
 
 
@@ -26,8 +26,6 @@ def init():
     json
     """
     try:
-
-        raise Exception("admin: {}, login: {}, can access: {}".format(session['user']['admin'], current_app.iniconfig.get('askomics', 'enable_sparql_console', fallback=False), can_access(session['user'])))
         # Disk space
         files_utils = FilesUtils(current_app, session)
         disk_space = files_utils.get_size_occupied_by_user() if "user" in session else None

--- a/askomics/api/sparql.py
+++ b/askomics/api/sparql.py
@@ -1,6 +1,6 @@
 import traceback
 import sys
-from askomics.api.auth import login_required
+from askomics.api.auth import admin_required, login_required
 from askomics.libaskomics.FilesUtils import FilesUtils
 from askomics.libaskomics.Result import Result
 from askomics.libaskomics.SparqlQuery import SparqlQuery
@@ -53,7 +53,7 @@ def init():
         "diskSpace": disk_space
     })
 
-
+@admin_required
 @sparql_bp.route('/api/sparql/previewquery', methods=['POST'])
 def query():
     """Perform a sparql query
@@ -122,7 +122,7 @@ def query():
         'data': data
     })
 
-
+@admin_required
 @sparql_bp.route('/api/sparql/savequery', methods=["POST"])
 @login_required
 def save_query():

--- a/askomics/api/sparql.py
+++ b/askomics/api/sparql.py
@@ -1,6 +1,6 @@
 import traceback
 import sys
-from askomics.api.auth import admin_required, login_required
+from askomics.api.auth import login_required
 from askomics.libaskomics.FilesUtils import FilesUtils
 from askomics.libaskomics.Result import Result
 from askomics.libaskomics.SparqlQuery import SparqlQuery

--- a/askomics/api/sparql.py
+++ b/askomics/api/sparql.py
@@ -8,8 +8,12 @@ from askomics.libaskomics.SparqlQueryLauncher import SparqlQueryLauncher
 
 from flask import (Blueprint, current_app, jsonify, request, session)
 
-
 sparql_bp = Blueprint('sparql', __name__, url_prefix='/')
+
+
+def can_access(user):
+    login_allowed = current_app.iniconfig.get('askomics', 'enable_sparql_console', fallback=False)
+    return login_allowed or user['admin']
 
 
 @sparql_bp.route("/api/sparql/init", methods=["GET"])
@@ -33,6 +37,8 @@ def init():
         # Default query
         default_query = query.prefix_query(query.get_default_query())
 
+        console_enabled = can_access(session['user'])
+
     except Exception as e:
         traceback.print_exc(file=sys.stdout)
         return jsonify({
@@ -41,7 +47,8 @@ def init():
             "defaultQuery": "",
             "graphs": {},
             "endpoints": {},
-            "diskSpace": None
+            "diskSpace": None,
+            "console_enabled": False
         }), 500
 
     return jsonify({
@@ -50,12 +57,13 @@ def init():
         "defaultQuery": default_query,
         "graphs": graphs,
         "endpoints": endpoints,
-        "diskSpace": disk_space
+        "diskSpace": disk_space,
+        "console_enabled": console_enabled
     })
 
 
-@admin_required
 @sparql_bp.route('/api/sparql/previewquery', methods=['POST'])
+@login_required
 def query():
     """Perform a sparql query
 
@@ -64,6 +72,10 @@ def query():
     json
         query results
     """
+
+    if not can_access(session['user']):
+        return jsonify({"error": True, "errorMessage": "Admin required"}), 401
+
     q = request.get_json()['query']
     graphs = request.get_json()['graphs']
     endpoints = request.get_json()['endpoints']
@@ -124,7 +136,6 @@ def query():
     })
 
 
-@admin_required
 @sparql_bp.route('/api/sparql/savequery', methods=["POST"])
 @login_required
 def save_query():
@@ -135,6 +146,10 @@ def save_query():
     json
         query results
     """
+
+    if not can_access(session['user']):
+        return jsonify({"error": True, "errorMessage": "Admin required"}), 401
+
     q = request.get_json()['query']
     graphs = request.get_json()['graphs']
     endpoints = request.get_json()['endpoints']

--- a/askomics/api/sparql.py
+++ b/askomics/api/sparql.py
@@ -26,6 +26,8 @@ def init():
     json
     """
     try:
+
+        raise Exception("admin: {}, login: {}, can access: {}".format(session['user']['admin'], current_app.iniconfig.get('askomics', 'enable_sparql_console', fallback=False), can_access(session['user'])))
         # Disk space
         files_utils = FilesUtils(current_app, session)
         disk_space = files_utils.get_size_occupied_by_user() if "user" in session else None

--- a/askomics/api/sparql.py
+++ b/askomics/api/sparql.py
@@ -53,6 +53,7 @@ def init():
         "diskSpace": disk_space
     })
 
+
 @admin_required
 @sparql_bp.route('/api/sparql/previewquery', methods=['POST'])
 def query():
@@ -121,6 +122,7 @@ def query():
         'header': header,
         'data': data
     })
+
 
 @admin_required
 @sparql_bp.route('/api/sparql/savequery', methods=["POST"])

--- a/askomics/react/src/routes/sparql/sparql.jsx
+++ b/askomics/react/src/routes/sparql/sparql.jsx
@@ -260,8 +260,8 @@ export default class Sparql extends Component {
       warningDiskSpace = (
         <div>
           <Alert color="warning">
-              Your files (uploaded files and results) take {this.utils.humanFileSize(this.state.diskSpace, true)} of space 
-              (you have {this.utils.humanFileSize(this.state.config.user.quota, true)} allowed). 
+              Your files (uploaded files and results) take {this.utils.humanFileSize(this.state.diskSpace, true)} of space
+              (you have {this.utils.humanFileSize(this.state.config.user.quota, true)} allowed).
               Please delete some before save queries or contact an admin to increase your quota
           </Alert>
         </div>
@@ -277,8 +277,8 @@ export default class Sparql extends Component {
     // launch buttons
     let previewButton
     let launchQueryButton
-    previewButton = <Button onClick={this.previewQuery} color="secondary" disabled={this.state.disablePreview}>{previewIcon} Run & preview</Button>
-    if (this.state.config.logged) {
+    if (this.state.config.user.admin){
+      previewButton = <Button onClick={this.previewQuery} color="secondary" disabled={this.state.disablePreview}>{previewIcon} Run & preview</Button>
       launchQueryButton = <Button onClick={this.launchQuery} color="secondary" disabled={this.state.disableSave || this.state.exceededQuota}><i className={"fas fa-" + this.state.saveIcon}></i> Run & save</Button>
     }
 
@@ -304,6 +304,7 @@ export default class Sparql extends Component {
             editorProps={{ $blockScrolling: true }}
             height={this.state.editorHeight}
             width={this.state.editorWidth}
+            readOnly={!this.state.config.user.admin}
           />
         </div>
         <br />

--- a/askomics/react/src/routes/sparql/sparql.jsx
+++ b/askomics/react/src/routes/sparql/sparql.jsx
@@ -35,6 +35,8 @@ export default class Sparql extends Component {
       endpoints: {},
       exceededQuota: false,
       diskSpace: 0,
+      console_enabled: false,
+      
       // save query icons
       disableSave: false,
       saveIcon: "play",
@@ -277,7 +279,7 @@ export default class Sparql extends Component {
     // launch buttons
     let previewButton
     let launchQueryButton
-    if (this.state.config.user.admin){
+    if (this.state.console_enabled){
       previewButton = <Button onClick={this.previewQuery} color="secondary" disabled={this.state.disablePreview}>{previewIcon} Run & preview</Button>
       launchQueryButton = <Button onClick={this.launchQuery} color="secondary" disabled={this.state.disableSave || this.state.exceededQuota}><i className={"fas fa-" + this.state.saveIcon}></i> Run & save</Button>
     }
@@ -304,7 +306,7 @@ export default class Sparql extends Component {
             editorProps={{ $blockScrolling: true }}
             height={this.state.editorHeight}
             width={this.state.editorWidth}
-            readOnly={!this.state.config.user.admin}
+            readOnly={!this.state.console_enabled}
           />
         </div>
         <br />

--- a/config/askomics.ini.template
+++ b/config/askomics.ini.template
@@ -43,6 +43,9 @@ disable_integration = false
 # Show public data and query only for logged users
 protect_public = false
 
+# Allow non-admin logged user to use the sparql console /!\ This is unsafe /!\
+enable_sparql_console = false
+
 # User quota
 # Default disk usage quota for user (0 = unlimited, <value>M or <value>G)
 # Exemple: 500M, 1G ...

--- a/config/askomics.test.ini
+++ b/config/askomics.test.ini
@@ -37,6 +37,9 @@ disable_integration = false
 # Show public data and query only for logged users
 protect_public = false
 
+# Allow non-admin logged user to use the sparql console /!\ This is unsafe /!\
+enable_sparql_console = false
+
 # User quota
 # Default disk usage quota for user (0 = unlimited, <value><unit>)
 # Exemple: 500MB, 1GB ...

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -28,6 +28,7 @@ All AskOmics configuration is set in `config/askomics.ini` files. When AskOmics 
     - `default_locked_account` (`true` or `false`): Lock new account
     - `disable_integration` (`true` or `false`): Disable integration to non admin users
     - `protect_public` (`true` or `false`): Public datasets and queries are visible only for logged users
+    - `enable_sparql_console`(`true` or `false`): Allow non-admin logged users to use the sparql console. **This is unsafe.**
     - `quota` (size): Default quota for new users
     - `github` (url): Github repository URL
     - `instance_url` (url): Instance URL. Used to send link by email when user reset his password

--- a/tests/results/init.json
+++ b/tests/results/init.json
@@ -1,6 +1,7 @@
 {
   "defaultQuery": "PREFIX : <http://askomics.org/test/data/>\nPREFIX askomics: <http://askomics.org/test/internal/>\nPREFIX dc: <http://purl.org/dc/elements/1.1/>\nPREFIX faldo: <http://biohackathon.org/resource/faldo/>\nPREFIX owl: <http://www.w3.org/2002/07/owl#>\nPREFIX prov: <http://www.w3.org/ns/prov#>\nPREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\nPREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\nPREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n\nSELECT DISTINCT ?s ?p ?o\nWHERE {\n    ?s ?p ?o\n}\n",
   "diskSpace": ###SIZE###,
+  "console_enabled": true,
   "endpoints": {
     "###LOCAL_ENDPOINT###": {
       "name": "local triplestore",

--- a/tests/test_api_sparql.py
+++ b/tests/test_api_sparql.py
@@ -25,8 +25,6 @@ class TestApiSparql(AskomicsTestCase):
         content = content.replace("###SIZE###", str(client.get_size_occupied_by_user()))
         expected = json.loads(content)
 
-        print(response.json)
-
         assert response.status_code == 200
         assert self.equal_objects(response.json, expected)
 

--- a/tests/test_api_sparql.py
+++ b/tests/test_api_sparql.py
@@ -25,6 +25,8 @@ class TestApiSparql(AskomicsTestCase):
         content = content.replace("###SIZE###", str(client.get_size_occupied_by_user()))
         expected = json.loads(content)
 
+        print(response.json)
+
         assert response.status_code == 200
         assert self.equal_objects(response.json, expected)
 


### PR DESCRIPTION
Should fix #169 

Added a config option for the sparql console
Option is enable_sparql_console, and default is false.

When set to false, the console itself is read-only for non-admin, and the endpoints are admin-restricted.

When set to true, the console is available to logged users.
In any case, endpoints are no longer available to non-logged users.




