### PR TITLE
Add a route to avoid 404 in URIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ help:
 	@echo '    make serve [MODE=dev] [HOST=0.0.0.0] [PORT=5000] [NTASKS=1]        Serve AskOmics at $(HOST):$(PORT)'
 	@echo '    make test                                                          Lint and test javascript and python code'
 	@echo '    make serve-doc [DOCPORT=8000]                                      Serve documentation at localhost:$(DOCPORT)'
+	@echo '    make update-base-url                                               Update all graphs from an old base_url to a new base_url'
+	@echo '    make clear-cache                                                   Clear abstraction cache'
 	@echo ''
 	@echo 'Examples:'
 	@echo '    make clean install build serve NTASKS=10                           Clean install and serve AskOmics in production mode, 10 celery tasks in parallel'
@@ -131,6 +133,18 @@ create-user:
 	@echo -n 'Creating first user...                                       '
 	. $(ACTIVATE)
 	bash cli/set_user.sh
+	@echo 'Done'
+
+update-base-url: check-venv
+	@echo 'Updating base url...'
+	. $(ACTIVATE)
+	bash cli/update_base_url.sh
+	@echo 'Done'
+
+clear-cache: check-venv
+	@echo 'Clearing abstraction cache...'
+	. $(ACTIVATE)
+	bash cli/clear_cache.sh
 	@echo 'Done'
 
 build: build-js

--- a/askomics/api/data.py
+++ b/askomics/api/data.py
@@ -1,0 +1,61 @@
+"""Api routes"""
+import sys
+import traceback
+
+from askomics.libaskomics.SparqlQuery import SparqlQuery
+from askomics.libaskomics.SparqlQueryLauncher import SparqlQueryLauncher
+
+from flask import (Blueprint, current_app, jsonify, session)
+
+
+data_bp = Blueprint('data', __name__, url_prefix='/')
+
+
+@data_bp.route('/api/data/<string:uri>', methods=['GET'])
+def get_data(uri):
+    """Get information about uri
+
+    Returns
+    -------
+    json
+        error: True if error, else False
+        errorMessage: the error message of error, else an empty string
+    """
+
+    try:
+        query = SparqlQuery(current_app, session)
+        graphs, endpoints = query.get_graphs_and_endpoints(all_selected=True)
+
+        endpoints = [val['uri'] for val in endpoints.values()]
+
+        data = []
+
+        # If the user do not have access to any endpoint (no viewable graph), skip
+        if endpoints:
+
+            base_uri = current_app.iniconfig.get('triplestore', 'namespace_data')
+            full_uri = "<%s%s>" % (base_uri, uri)
+
+            raw_query = "SELECT DISTINCT ?predicat ?object\nWHERE {\n%s ?predicat ?object\n}" % (full_uri)
+            federated = query.is_federated()
+            replace_froms = query.replace_froms()
+
+            sparql = query.format_query(raw_query, replace_froms=replace_froms, federated=federated)
+
+            query_launcher = SparqlQueryLauncher(current_app, session, get_result_query=True, federated=federated, endpoints=endpoints)
+            header, data = query_launcher.process_query(sparql)
+
+    except Exception as e:
+        current_app.logger.error(str(e).replace('\\n', '\n'))
+        traceback.print_exc(file=sys.stdout)
+        return jsonify({
+            'error': True,
+            'errorMessage': str(e).replace('\\n', '\n'),
+            'data': []
+        }), 500
+
+    return jsonify({
+        'data': data,
+        'error': False,
+        'errorMessage': ""
+    })

--- a/askomics/app.py
+++ b/askomics/app.py
@@ -10,6 +10,7 @@ import configparser
 
 from askomics.api.admin import admin_bp
 from askomics.api.auth import auth_bp
+from askomics.api.data import data_bp
 from askomics.api.datasets import datasets_bp
 from askomics.api.file import file_bp
 from askomics.api.sparql import sparql_bp
@@ -41,6 +42,7 @@ BLUEPRINTS = (
     auth_bp,
     admin_bp,
     file_bp,
+    data_bp,
     datasets_bp,
     query_bp,
     results_bp,

--- a/askomics/libaskomics/LocalAuth.py
+++ b/askomics/libaskomics/LocalAuth.py
@@ -1303,3 +1303,25 @@ class LocalAuth(Params):
         graphs = tse.get_graph_of_user(username)
         for graph in graphs:
             Utils.redo_if_failure(self.log, 3, 1, query_launcher.drop_dataset, graph)
+
+    def update_base_url(self, old_url, new_url):
+        """Update base url for all graphs
+
+        Parameters
+        ----------
+        old_url : string
+            Previous base url
+        new_url : string
+            New base url
+        """
+        tse = TriplestoreExplorer(self.app, self.session)
+        graphs = tse.get_all_graphs()
+
+        for graph in graphs:
+            tse.update_base_url(graph, old_url, new_url)
+
+    def clear_abstraction_cache(self):
+        """Clear cache for all users"""
+
+        tse = TriplestoreExplorer(self.app, self.session)
+        tse.uncache_abstraction(public=True, force=True)

--- a/askomics/react/src/routes.jsx
+++ b/askomics/react/src/routes.jsx
@@ -6,6 +6,7 @@ import Ask from './routes/ask/ask'
 import About from './routes/about/about'
 import Upload from './routes/upload/upload'
 import Integration from './routes/integration/integration'
+import Data from './routes/data/data'
 import Datasets from './routes/datasets/datasets'
 import Signup from './routes/login/signup'
 import Login from './routes/login/login'
@@ -112,6 +113,7 @@ export default class Routes extends Component {
             <Route path="/query" exact component={Query} />
             <Route path="/results" exact component={() => (<Results config={this.state.config} waitForStart={this.state.waiting} />)} />
             <Route path="/sparql" render={(props) => <Sparql config={this.state.config} waitForStart={this.state.waiting} {...props}/>}/>
+            <Route path="/data/:uri" exact component={() => (<Data config={this.state.config} waitForStart={this.state.waiting} />)} />
             {integrationRoutes}
           </Switch>
           <br />

--- a/askomics/react/src/routes/data/data.jsx
+++ b/askomics/react/src/routes/data/data.jsx
@@ -111,7 +111,8 @@ class Data extends Component {
 
 Data.propTypes = {
   waitForStart: PropTypes.bool,
-  config: PropTypes.object
+  config: PropTypes.object,
+  match: PropTypes.object
 }
 
 export default withRouter(Data)

--- a/askomics/react/src/routes/data/data.jsx
+++ b/askomics/react/src/routes/data/data.jsx
@@ -1,0 +1,117 @@
+import React, { Component } from 'react'
+import axios from 'axios'
+import { Button, Form, FormGroup, Label, Input, Alert, Row, Col, CustomInput } from 'reactstrap'
+import BootstrapTable from 'react-bootstrap-table-next'
+import paginationFactory from 'react-bootstrap-table2-paginator'
+import cellEditFactory from 'react-bootstrap-table2-editor'
+import update from 'react-addons-update'
+import { withRouter } from "react-router-dom";
+import PropTypes from 'prop-types'
+import Utils from '../../classes/utils'
+import { Redirect } from 'react-router-dom'
+import WaitingDiv from '../../components/waiting'
+import ErrorDiv from '../error/error'
+
+class Data extends Component {
+  constructor (props) {
+    super(props)
+    this.utils = new Utils()
+    this.state = { 
+      isLoading: true,
+      error: false,
+      errorMessage: '',
+      data: [],
+    }
+  }
+
+  componentDidMount () {
+    if (!this.props.waitForStart) {
+      this.loadData()
+    }
+  }
+
+  loadData() {
+    let uri = this.props.match.params.uri;
+    let requestUrl = '/api/data/' + uri 
+    axios.get(requestUrl, { baseURL: this.props.config.proxyPath, cancelToken: new axios.CancelToken((c) => { this.cancelRequest = c }) })
+      .then(response => {
+        console.log(requestUrl, response.data)
+        this.setState({
+          isLoading: false,
+          data: response.data.data,
+        })
+      })
+      .catch(error => {
+        console.log(error, error.response.data.errorMessage)
+        this.setState({
+          error: true,
+          errorMessage: error.response.data.errorMessage,
+          success: !error.response.data.error
+        })
+      })
+  }
+
+  componentWillUnmount () {
+    if (!this.props.waitForStart) {
+      this.cancelRequest()
+    }
+  }
+
+  render () {
+    let uri = this.props.match.params.uri;
+
+    let columns = [{
+      dataField: 'predicat',
+      text: 'Property',
+      sort: true,
+      formatter: (cell, row) => {
+        if (this.utils.isUrl(cell)) {
+          return this.utils.splitUrl(cell)
+        }
+        return cell
+      }
+    },{
+      dataField: 'object',
+      text: 'Value',
+      sort: true,
+      formatter: (cell, row) => {
+        if (this.utils.isUrl(cell)) {
+          if (cell.startsWith(this.props.config.namespaceInternal)){
+            return this.utils.splitUrl(cell)
+          } else {
+            return <a href={cell}>{this.utils.splitUrl(cell)}</a>
+          }
+        }
+        return cell
+      }
+    }]
+
+
+    return (
+      <div className="container">
+        <h2>Information about uri {uri}</h2>
+        <br />        
+        <div className="asko-table-height-div">
+          <BootstrapTable
+            classes="asko-table"
+            wrapperClasses="asko-table-wrapper"
+            tabIndexCell
+            bootstrap4
+            keyField='id'
+            data={this.state.data}
+            columns={columns}
+            pagination={paginationFactory()}
+            noDataIndication={'No results for this URI. You may not have access to any graph including it.'}
+          />
+        </div>
+      </div>
+    )
+  }
+}
+
+Data.propTypes = {
+  waitForStart: PropTypes.bool,
+  config: PropTypes.object
+}
+
+export default withRouter(Data)

--- a/cli/clear_cache.py
+++ b/cli/clear_cache.py
@@ -1,0 +1,48 @@
+"""CLI to clear cache for all users"""
+import argparse
+
+from askomics.app import create_app, create_celery
+from askomics.libaskomics.LocalAuth import LocalAuth
+from askomics.libaskomics.Start import Start
+
+
+class ClearCache(object):
+    """Update base_url for all graphs
+
+    Attributes
+    ----------
+    application : Flask app
+        Flask App
+    args : args
+        User arguments
+    celery : Celery
+        Celery
+    session : dict
+        Empty session
+    """
+
+    def __init__(self):
+        """Get Args"""
+        parser = argparse.ArgumentParser(description="Update base_url for all graphs")
+
+        parser.add_argument("-c", "--config-file", type=str, help="AskOmics config file", required=True)
+
+        self.args = parser.parse_args()
+
+        self.application = create_app(config=self.args.config_file)
+        self.celery = create_celery(self.application)
+        self.session = {}
+        starter = Start(self.application, self.session)
+        starter.start()
+
+    def main(self):
+        """Update graphs"""
+
+        local_auth = LocalAuth(self.application, self.session)
+        self.application.logger.info("Clearing abstraction cache")
+        local_auth.clear_abstraction_cache()
+
+
+if __name__ == '__main__':
+    """main"""
+    ClearCache().main()

--- a/cli/clear_cache.sh
+++ b/cli/clear_cache.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+python3 cli/clear_cache.py -c config/askomics.ini

--- a/cli/update_base_url.py
+++ b/cli/update_base_url.py
@@ -1,0 +1,78 @@
+"""CLI to update base_url for all graphs"""
+import argparse
+import sys
+
+from askomics.app import create_app, create_celery
+from askomics.libaskomics.LocalAuth import LocalAuth
+from askomics.libaskomics.Start import Start
+
+
+class UpdateUrl(object):
+    """Update base_url for all graphs
+
+    Attributes
+    ----------
+    application : Flask app
+        Flask App
+    args : args
+        User arguments
+    celery : Celery
+        Celery
+    session : dict
+        Empty session
+    """
+
+    def __init__(self):
+        """Get Args"""
+        parser = argparse.ArgumentParser(description="Update base_url for all graphs")
+
+        parser.add_argument("-c", "--config-file", type=str, help="AskOmics config file", required=True)
+        parser.add_argument("-o", "--old_url", type=str, help="Old base url", required=True)
+        parser.add_argument("-n", "--new_url", type=str, help="New base url", required=True)
+
+        self.args = parser.parse_args()
+
+        if not (self.args.old_url and self.args.new_url):
+            print("Error: old_url and new_url must not be empty")
+            sys.exit(1)
+
+        self.check_urls(self.args.old_url, self.args.new_url)
+
+        self.application = create_app(config=self.args.config_file)
+        self.celery = create_celery(self.application)
+        self.session = {}
+        starter = Start(self.application, self.session)
+        starter.start()
+
+    def check_urls(self, old_url, new_url):
+        # Some checks
+        if not (old_url.startswith("http://") or old_url.startswith("https://")):
+            print("Error: old_url must starts with either http:// or https://")
+            sys.exit(1)
+        if not (new_url.startswith("http://") or new_url.startswith("https://")):
+            print("Error: new_url must starts with either http:// or https://")
+            sys.exit(1)
+
+        if not (old_url.endswith("/") and new_url.endswith("/")):
+            print("Error: Both urls must have a trailing /")
+            sys.exit(1)
+
+        if old_url.endswith("/data/") and not new_url.endswith("/data/"):
+            print("Error: Make sure the new url ends with /data/ too")
+            sys.exit(1)
+
+        if old_url.endswith("/internal/") and not new_url.endswith("/internal/"):
+            print("Error: Make sure the new url ends with /internal/ too")
+            sys.exit(1)
+
+    def main(self):
+        """Update graphs"""
+
+        local_auth = LocalAuth(self.application, self.session)
+        self.application.logger.info("Update base url from {} to {}".format(self.args.old_url, self.args.new_url))
+        local_auth.update_base_url(self.args.old_url, self.args.new_url)
+
+
+if __name__ == '__main__':
+    """main"""
+    UpdateUrl().main()

--- a/cli/update_base_url.sh
+++ b/cli/update_base_url.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+echo "This script will update the base url in all graphs."
+echo "You can specify either a base url (http://askomics.org/), or a full endpoint (http://askomics.org/data/)"
+echo "Make sure to write a valid url (starting with either http:// or https://, and ending with a trailing /)"
+echo ""
+read -p "Old base url (ex: http://askomics.org/data/) : " OLD_URL
+read -p "New base url (ex: http://my_new_url.com/data/) : " NEW_URL
+
+python3 cli/update_base_url.py -c config/askomics.ini --old_url $OLD_URL --new_url $NEW_URL

--- a/tests/results/data.json
+++ b/tests/results/data.json
@@ -1,0 +1,50 @@
+{
+    "data": [
+        {
+            "object": "http://askomics.org/test/data/transcript",
+            "predicat": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        },
+        {
+            "object": "AT3G10490",
+            "predicat": "http://www.w3.org/2000/01/rdf-schema#label"
+        },
+        {
+            "object": "protein_coding",
+            "predicat": "http://askomics.org/test/data/biotype"
+        },
+        {
+            "object": "NAC_domain_containing_protein_52_[Source:TAIR%3BAcc:AT3G10490]",
+            "predicat": "http://askomics.org/test/data/description"
+        },
+        {
+            "object": "ANAC052",
+            "predicat": "http://askomics.org/test/data/featureName"
+        },
+        {
+            "object": "http://askomics.org/test/data/gene",
+            "predicat": "http://askomics.org/test/data/featureType"
+        },
+        {
+            "object": "http://askomics.org/test/data/Arabidopsis_thaliana",
+            "predicat": "http://askomics.org/test/data/taxon"
+        },
+        {
+            "object": "326",
+            "predicat": "http://askomics.org/test/internal/includeIn"
+        },
+        {
+            "object": "327",
+            "predicat": "http://askomics.org/test/internal/includeIn"
+        },
+        {
+            "object": "http://askomics.org/test/data/At3_326",
+            "predicat": "http://askomics.org/test/internal/includeInReference"
+        },
+        {
+            "object": "http://askomics.org/test/data/At3_327",
+            "predicat": "http://askomics.org/test/internal/includeInReference"
+        }
+    ],
+    "error": false,
+    "errorMessage": ""
+}

--- a/tests/test_api_data.py
+++ b/tests/test_api_data.py
@@ -1,0 +1,80 @@
+import json
+
+from . import AskomicsTestCase
+
+
+class TestApiData(AskomicsTestCase):
+    """Test AskOmics API /data/<uri>"""
+
+    def test_get_uri(self, client):
+        """test the /data/<uri> route"""
+        client.create_two_users()
+        client.log_user("jdoe")
+        client.upload_and_integrate()
+
+        with open("tests/results/data.json", "r") as file:
+            file_content = file.read()
+        expected = json.loads(file_content)
+
+        response = client.client.get('/api/data/AT3G10490')
+
+        # Remove this dict since the node value seems to change (dependant on load order maybe?)
+        response.json['data'] = [val for val in response.json['data'] if not val['predicat'] == "http://biohackathon.org/resource/faldo/location"]
+
+        assert response.status_code == 200
+        assert self.equal_objects(response.json, expected)
+
+    def test_get_empty_uri(self, client):
+        """test the /data/<uri> route for an empty uri"""
+        response = client.client.get('/api/data/random_uri')
+
+        expected_empty_response = {
+            'data': [],
+            'error': False,
+            'errorMessage': ""
+        }
+
+        assert response.status_code == 200
+        assert response.json == expected_empty_response
+
+    def test_uri_access(self, client):
+        """test the /data/<uri> route for public and non public uris"""
+        client.create_two_users()
+        client.log_user("jdoe")
+        client.upload_and_integrate()
+
+        expected_empty_response = {
+            'data': [],
+            'error': False,
+            'errorMessage': ""
+        }
+
+        client.log_user("jsmith")
+        response = client.client.get('/api/data/AT3G10490')
+
+        assert response.status_code == 200
+        assert response.json == expected_empty_response
+
+    def test_public_access(self, client):
+        """test the /data/<uri> route for public and non public uris"""
+        client.create_two_users()
+        client.log_user("jdoe")
+        client.upload_file("test-data/transcripts.tsv")
+
+        client.integrate_file({
+            "id": 1,
+            "columns_type": ["start_entity", "category", "text", "reference", "start", "end", "category", "strand", "text", "text"]
+        }, public=True)
+
+        with open("tests/results/data.json", "r") as file:
+            file_content = file.read()
+        expected = json.loads(file_content)
+
+        client.logout()
+        response = client.client.get('/api/data/AT3G10490')
+
+        # Remove this dict since the node value seems to change (dependant on load order maybe?)
+        response.json['data'] = [val for val in response.json['data'] if not val['predicat'] == "http://biohackathon.org/resource/faldo/location"]
+
+        assert response.status_code == 200
+        assert self.equal_objects(response.json, expected)


### PR DESCRIPTION
- Added the /data/<uri> route 
This route will search all available graphes to the user and print all predicates and objects related to the uri.
The graph will be empty if no results are available (no access, or no data).

![image](https://user-images.githubusercontent.com/17642511/107229603-52769b80-6a1e-11eb-90ed-559578c8af21.png)

- Added the `update-base-url` make option
Since the default base url was `http://askomics.org`, this command will rewrite all users graphs to update the base url.
The admin will need to specify the old and new base urls. (Making sure it matches the url in the config file).
- Added the `clear-cache` make option
Since the abstraction cache is stored in the DB, the admin need to use this command to clear it after updating the base url.
- Added tests for the new api endpoints (and checks for visibility)

I will edit the documentation in another PR to add these commands.
