### PR TITLE
Fix 349

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This changelog was started for release 4.2.0.
 - Fixed markupsafe to 2.0.1
 - Increased Galaxy timeout for tests
 - Fix documentation build
+- Force all 'user queries'(ask/sparql interfaces) to go to the unauthenticated endpoint, to increase security (no write permissions)
 
 ### Security
 

--- a/askomics/libaskomics/SparqlQuery.py
+++ b/askomics/libaskomics/SparqlQuery.py
@@ -273,7 +273,7 @@ class SparqlQuery(Params):
         '''.format(graph=graph, public=public)
 
         query_launcher = SparqlQueryLauncher(self.app, self.session)
-        query_launcher.execute_query(self.prefix_query(query))
+        query_launcher.execute_query(self.prefix_query(query), is_update=True)
 
     def get_default_query_with_prefix(self):
         """Get default query with the prefixes

--- a/askomics/libaskomics/SparqlQueryLauncher.py
+++ b/askomics/libaskomics/SparqlQueryLauncher.py
@@ -265,7 +265,7 @@ class SparqlQueryLauncher(Params):
         """
         return self.parse_results(self.execute_query(query, isql_api=isql_api, is_update=is_update))
 
-    def execute_query(self, query, disable_log=False, isql_api=False, is_update=False):
+    def execute_query(self, query, disable_log=False, isql_api=False, is_update=False, drop=False):
         """Execute a sparql query
 
         Parameters
@@ -311,11 +311,8 @@ class SparqlQueryLauncher(Params):
                     self.endpoint.setMethod('POST')
                     # Force sending to secure endpoint
                     self.endpoint.queryType = "INSERT"
-                    # Virtuoso hack
-                    # if self.triplestore == 'virtuoso':
-                    #    self.endpoint.queryType = "SELECT"
-
                     results = self.endpoint.query()
+
                 # Select
                 else:
                     self.endpoint.setReturnFormat(JSON)

--- a/askomics/libaskomics/SparqlQueryLauncher.py
+++ b/askomics/libaskomics/SparqlQueryLauncher.py
@@ -265,7 +265,7 @@ class SparqlQueryLauncher(Params):
         """
         return self.parse_results(self.execute_query(query, isql_api=isql_api, is_update=is_update))
 
-    def execute_query(self, query, disable_log=False, isql_api=False, is_update=False, drop=False):
+    def execute_query(self, query, disable_log=False, isql_api=False, is_update=False):
         """Execute a sparql query
 
         Parameters

--- a/askomics/libaskomics/SparqlQueryLauncher.py
+++ b/askomics/libaskomics/SparqlQueryLauncher.py
@@ -163,7 +163,7 @@ class SparqlQueryLauncher(Params):
         )
 
         query = "LOAD <{}> INTO GRAPH <{}>".format(file_url, graph)
-        return self.execute_query(query)
+        return self.execute_query(query, is_update=True)
 
     def get_triples_from_graph(self, graph):
         """Get triples from a rdflib graph
@@ -206,7 +206,7 @@ class SparqlQueryLauncher(Params):
         }}
         '''.format(graph, ttl_string)
 
-        return self.execute_query(query)
+        return self.execute_query(query, is_update=True)
 
     def insert_data(self, ttl, graph, metadata=False):
         """Insert data into the triplesotre using INSERT
@@ -235,7 +235,7 @@ class SparqlQueryLauncher(Params):
         }}
         '''.format(graph, triples)
 
-        return self.execute_query(query)
+        return self.execute_query(query, is_update=True)
 
     def drop_dataset(self, graph):
         """Drop the datasets of the triplestore and its metadata
@@ -248,9 +248,9 @@ class SparqlQueryLauncher(Params):
         query = '''
         DROP SILENT GRAPH <{}>
         '''.format(graph)
-        self.execute_query(query, disable_log=True, isql_api=True)
+        self.execute_query(query, disable_log=True, isql_api=True, is_update=True)
 
-    def process_query(self, query, isql_api=False):
+    def process_query(self, query, isql_api=False, is_update=False):
         """Execute a query and return parsed results
 
         Parameters
@@ -263,9 +263,9 @@ class SparqlQueryLauncher(Params):
         list
             Parsed results
         """
-        return self.parse_results(self.execute_query(query, isql_api=isql_api))
+        return self.parse_results(self.execute_query(query, isql_api=isql_api, is_update=is_update))
 
-    def execute_query(self, query, disable_log=False, isql_api=False):
+    def execute_query(self, query, disable_log=False, isql_api=False, is_update=False):
         """Execute a sparql query
 
         Parameters
@@ -299,7 +299,7 @@ class SparqlQueryLauncher(Params):
 
             if use_isql:
                 formatted_query = "SPARQL {}".format(query)
-                json = {"command": formatted_query, "disable_log": disable_log, "sparql_select": not self.endpoint.isSparqlUpdateRequest()}
+                json = {"command": formatted_query, "disable_log": disable_log, "sparql_select": not is_update}
                 response = requests.post(url=isql_api_url, json=json)
                 results = response.json()
                 if results["status"] == 500:
@@ -307,8 +307,10 @@ class SparqlQueryLauncher(Params):
 
             else:
                 # Update
-                if self.endpoint.isSparqlUpdateRequest():
+                if is_update:
                     self.endpoint.setMethod('POST')
+                    # Force sending to secure endpoint
+                    self.endpoint.queryType = "INSERT"
                     # Virtuoso hack
                     # if self.triplestore == 'virtuoso':
                     #    self.endpoint.queryType = "SELECT"
@@ -317,6 +319,8 @@ class SparqlQueryLauncher(Params):
                 # Select
                 else:
                     self.endpoint.setReturnFormat(JSON)
+                    # Force sending to public endpoint
+                    self.endpoint.queryType = "SELECT"
                     results = self.endpoint.query().convert()
 
                 self.query_time = time.time() - start_time

--- a/config/askomics.test.ini
+++ b/config/askomics.test.ini
@@ -83,7 +83,7 @@ autocomplete_max_results = 20
 # name of the triplestore, can be virtuoso or fuseki
 triplestore = virtuoso
 # Sparql endpoint
-endpoint = http://localhost:8891/sparql-auth
+endpoint = http://localhost:8891/sparql
 # Sparql updatepoint
 updatepoint = http://localhost:8891/sparql-auth
 # Isql API

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -489,7 +489,7 @@ class Client(object):
         # integrate
         int_ontology = self.integrate_file({
             "id": 1,
-        }, set_graph=True, endpoint="http://localhost:8891/sparql-auth")
+        }, set_graph=True, endpoint="http://localhost:8891/sparql")
 
         return {
             "upload": up_ontology,
@@ -539,7 +539,7 @@ class Client(object):
         result.save_in_db(start=start)
 
         # Execute query and write result to file
-        headers, results = query_launcher.process_query(query.sparql, is_update=True)
+        headers, results = query_launcher.process_query(query.sparql)
         file_size = result.save_result_in_file(headers, results)
 
         # Update database status
@@ -584,7 +584,7 @@ class Client(object):
 
         query_launcher = SparqlQueryLauncher(self.app, {})
 
-        header, data = query_launcher.process_query(query, is_update=True)
+        header, data = query_launcher.process_query(query)
         for result in data:
             query_launcher.drop_dataset(result["graph"])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -539,7 +539,7 @@ class Client(object):
         result.save_in_db(start=start)
 
         # Execute query and write result to file
-        headers, results = query_launcher.process_query(query.sparql)
+        headers, results = query_launcher.process_query(query.sparql, is_update=True)
         file_size = result.save_result_in_file(headers, results)
 
         # Update database status
@@ -584,7 +584,7 @@ class Client(object):
 
         query_launcher = SparqlQueryLauncher(self.app, {})
 
-        header, data = query_launcher.process_query(query)
+        header, data = query_launcher.process_query(query, is_update=True)
         for result in data:
             query_launcher.drop_dataset(result["graph"])
 

--- a/tests/results/abstraction.json
+++ b/tests/results/abstraction.json
@@ -525,7 +525,7 @@
     "entities": [
       {
         "endpoints": [
-          "http://localhost:8891/sparql-auth"
+          "http://localhost:8891/sparql"
         ],
         "faldo": true,
         "graphs": [
@@ -540,7 +540,7 @@
       },
       {
         "endpoints": [
-          "http://localhost:8891/sparql-auth"
+          "http://localhost:8891/sparql"
         ],
         "faldo": true,
         "graphs": [
@@ -555,7 +555,7 @@
       },
       {
         "endpoints": [
-          "http://localhost:8891/sparql-auth"
+          "http://localhost:8891/sparql"
         ],
         "faldo": true,
         "graphs": [
@@ -569,7 +569,7 @@
       },
       {
         "endpoints": [
-          "http://localhost:8891/sparql-auth"
+          "http://localhost:8891/sparql"
         ],
         "faldo": false,
         "graphs": [

--- a/tests/results/startpoints.json
+++ b/tests/results/startpoints.json
@@ -8,10 +8,10 @@
     [{
         "endpoints": [{
             "name": "local",
-            "url": "http://localhost:8891/sparql-auth"
+            "url": "http://localhost:8891/sparql"
         }, {
             "name": "local",
-            "url": "http://localhost:8891/sparql-auth"
+            "url": "http://localhost:8891/sparql"
         }],
         "entity":
         "http://askomics.org/test/data/transcript",
@@ -37,10 +37,10 @@
      {
          "endpoints": [{
              "name": "local",
-             "url": "http://localhost:8891/sparql-auth"
+             "url": "http://localhost:8891/sparql"
          }, {
              "name": "local",
-             "url": "http://localhost:8891/sparql-auth"
+             "url": "http://localhost:8891/sparql"
          }],
          "entity":
          "http://askomics.org/test/data/gene",
@@ -70,7 +70,7 @@
      {
          "endpoints": [{
              "name": "local",
-             "url": "http://localhost:8891/sparql-auth"
+             "url": "http://localhost:8891/sparql"
          }],
          "entity":
          "http://askomics.org/test/data/DifferentialExpression",
@@ -89,7 +89,7 @@
      {
          "endpoints": [{
              "name": "local",
-             "url": "http://localhost:8891/sparql-auth"
+             "url": "http://localhost:8891/sparql"
          }],
          "entity":
          "http://askomics.org/test/data/QTL",


### PR DESCRIPTION
Should close #349 

This PR directly manage the sparql endpoint where queries are sent, instead of letting sparqlwrapper decide.
(Since 'Askomics' contains 'ask', it was not accurate anyway)

This means that any 'user' constructed query (namely, from the ask interface and the sparql console) will be set to the unauthentified endpoint, which does not have write access.

This means that a malicious user cannot delete data through the sparql console.