### PR TITLE
Add 'overview button' and fix GFF faldo issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,14 @@ This changelog was started for release 4.2.0.
 
 - Added 'anonymous_query' and 'anonymous_query_cleanup' variables
     - These enable 'anonymous query' mode, allowing anonymous users to send 'full queries'. See documentation
-
+- Added 'overview' button in the query page. This button will show all 'selected' attributes, and allow users to quickly select the related entity.
 
 ### Fixed
 
 - Fixed new linting
 - Fixed logs for production setup
 - Fixed profile update & password reset tab in user profile page
+- Fixed Gff Faldo integration (was only integrating the last selected entity)
 
 ### Changed
 

--- a/askomics/libaskomics/GffFile.py
+++ b/askomics/libaskomics/GffFile.py
@@ -433,4 +433,3 @@ class GffFile(File):
                 if (feature_type, related_qualifier_key) not in attribute_list:
                     link['range'] = self.namespace_data[self.format_uri(entity_type)]
                     self.attribute_abstraction.append(link)
-

--- a/askomics/libaskomics/GffFile.py
+++ b/askomics/libaskomics/GffFile.py
@@ -45,6 +45,13 @@ class GffFile(File):
 
         self.faldo_entity = True
 
+        self.faldo_abstraction = {
+            "start": [],
+            "end": [],
+            "strand": [],
+            "reference": []
+        }
+
     def set_preview(self):
         """Summary"""
         try:
@@ -133,7 +140,7 @@ class GffFile(File):
                 self.graph_abstraction_dk.add((blank, rdflib.RDFS.domain, attribute["domain"]))
                 self.graph_abstraction_dk.add((blank, rdflib.RDFS.range, attribute["range"]))
 
-            attribute_blanks[attribute["uri"]] = blank
+            attribute_blanks[(attribute['domain'], attribute["uri"])] = blank
             # Domain Knowledge
             if "values" in attribute.keys():
                 for value in attribute["values"]:
@@ -146,11 +153,12 @@ class GffFile(File):
 
         # Faldo:
         if self.faldo_entity:
-            for key, value in self.faldo_abstraction.items():
-                if value:
-                    blank = attribute_blanks[value]
-                    self.graph_abstraction_dk.add((blank, rdflib.RDF.type, self.faldo_abstraction_eq[key]))
-                    self.graph_abstraction_dk.add((blank, self.namespace_internal["uri"], value))
+            for key, values in self.faldo_abstraction.items():
+                if values:
+                    for val in values:
+                        blank = attribute_blanks[val]
+                        self.graph_abstraction_dk.add((blank, rdflib.RDF.type, self.faldo_abstraction_eq[key]))
+                        self.graph_abstraction_dk.add((blank, self.namespace_internal["uri"], val[1]))
 
     def format_gff_entity(self, entity):
         """Format a gff entity name by removing type (type:entity --> entity)
@@ -233,7 +241,7 @@ class GffFile(File):
                 relation = self.namespace_data[self.format_uri("reference")]
                 attribute = self.namespace_data[self.format_uri(rec.id)]
                 faldo_reference = attribute
-                self.faldo_abstraction["reference"] = relation
+                self.faldo_abstraction["reference"].append((entity_type, relation))
                 # self.graph_chunk.add((entity, relation, attribute))
 
                 if (feature.type, "reference") not in attribute_list:
@@ -256,7 +264,7 @@ class GffFile(File):
                 relation = self.namespace_data[self.format_uri("start")]
                 attribute = rdflib.Literal(self.convert_type(feature.location.start))
                 faldo_start = attribute
-                self.faldo_abstraction["start"] = relation
+                self.faldo_abstraction["start"].append((entity_type, relation))
                 # self.graph_chunk.add((entity, relation, attribute))
 
                 if (feature.type, "start") not in attribute_list:
@@ -273,7 +281,7 @@ class GffFile(File):
                 relation = self.namespace_data[self.format_uri("end")]
                 attribute = rdflib.Literal(self.convert_type(feature.location.end))
                 faldo_end = attribute
-                self.faldo_abstraction["end"] = relation
+                self.faldo_abstraction["end"].append((entity_type, relation))
                 # self.graph_chunk.add((entity, relation, attribute))
 
                 if (feature.type, "end") not in attribute_list:
@@ -292,7 +300,7 @@ class GffFile(File):
                     relation = self.namespace_data[self.format_uri("strand")]
                     attribute = self.namespace_data[self.format_uri("+")]
                     faldo_strand = self.get_faldo_strand("+")
-                    self.faldo_abstraction["strand"] = relation
+                    self.faldo_abstraction["strand"].append((entity_type, relation))
                     strand_type = "+"
                     # self.graph_chunk.add((entity, relation, attribute))
                 elif feature.location.strand == -1:
@@ -300,7 +308,7 @@ class GffFile(File):
                     relation = self.namespace_data[self.format_uri("strand")]
                     attribute = self.namespace_data[self.format_uri("-")]
                     faldo_strand = self.get_faldo_strand("-")
-                    self.faldo_abstraction["strand"] = relation
+                    self.faldo_abstraction["strand"].append((entity_type, relation))
                     strand_type = "-"
                     # self.graph_chunk.add((entity, relation, attribute))
                 else:
@@ -308,7 +316,7 @@ class GffFile(File):
                     relation = self.namespace_data[self.format_uri("strand")]
                     attribute = self.namespace_data[self.format_uri(".")]
                     faldo_strand = self.get_faldo_strand(".")
-                    self.faldo_abstraction["strand"] = relation
+                    self.faldo_abstraction["strand"].append((entity_type, relation))
                     strand_type = "."
 
                 if (feature.type, "strand", strand_type) not in attribute_list:
@@ -425,3 +433,4 @@ class GffFile(File):
                 if (feature_type, related_qualifier_key) not in attribute_list:
                     link['range'] = self.namespace_data[self.format_uri(entity_type)]
                     self.attribute_abstraction.append(link)
+

--- a/askomics/react/src/routes/query/overviewModal.jsx
+++ b/askomics/react/src/routes/query/overviewModal.jsx
@@ -1,0 +1,214 @@
+import React, { Component} from 'react'
+import { Button, Modal, ModalHeader, ModalBody, ModalFooter, ButtonGroup, Input } from 'reactstrap'
+import { Redirect } from 'react-router-dom'
+import ReactTooltip from "react-tooltip";
+import ErrorDiv from '../error/error'
+import WaitingDiv from '../../components/waiting'
+import update from 'react-addons-update'
+import PropTypes from 'prop-types'
+import Utils from '../../classes/utils'
+
+export default class OverviewModal extends Component {
+  constructor (props) {
+    super(props)
+    this.utils = new Utils()
+    this.state = {
+      modal: false,
+    }
+    this.toggleModal = this.toggleModal.bind(this)
+  }
+
+  toggleModal () {
+    this.setState({
+      modal: !this.state.modal
+    })
+  }
+
+  renderLinker (attribute) {
+    const linked = this.props.graphState.attributes.find(attr => attr.id == attribute.linkedWith);
+    return (
+        <CustomInput disabled value={linked.displayLabel}/>
+      )
+  }
+
+  renderIcons(attribute){
+
+    if (!(attribute.form || attribute.visible || attribute.optional || attribute.linked || attribute.exclude)){
+      return false
+    }
+
+    let formIcon
+    if (attribute.form) {
+      formIcon = 'attr-icon fas fa-bookmark '
+    }
+
+    let eyeIcon
+    if (attribute.visible) {
+      eyeIcon = 'attr-icon fas fa-eye'
+    }
+
+    let optionalIcon
+    if (attribute.optional) {
+      optionalIcon = 'attr-icon fas fa-question-circle'
+    }
+
+    let linkIcon
+    if (attribute.linked) {
+      linkIcon = 'attr-icon fas fa-link'
+    }
+
+    let excludeIcon
+    if (attribute.exclude) {
+      excludeIcon = 'attr-icon fas fa-ban'
+    }
+    return (
+      <div className="attr-icons">
+        {formIcon ? <i className={formIcon}></i> : <nodiv></nodiv>}
+        {linkIcon ? <i className={linkIcon}></i> : <nodiv></nodiv>}
+        {optionalIcon ? <i className={optionalIcon}></i> : <nodiv></nodiv>}
+        {excludeIcon ? <i className={excludeIcon}></i> : <nodiv></nodiv>}
+        {eyeIcon ? <i className={eyeIcon}></i> : <nodiv></nodiv>}
+      </div>
+    )
+  }
+
+  renderTextField (attribute){
+    if (attribute.linked && attribute.linkedWith){
+      return this.renderLinker(attribute)
+    }
+
+    if (!attribute.filterValue){
+      return false
+    }
+
+    let selected_sign = attribute.negative ? "≠" : '='
+
+    return form = (
+      <table style={{ width: '100%' }}>
+        <tr>
+          <td>
+            <CustomInput disabled value={attribute.filterType}/>
+          </td>
+          <td>
+            <CustomInput disabled value={selected_sign}/>
+          </td>
+          <td>
+            <CustomInput disabled value={attribute.filterValue}/>
+          </td>
+        </tr>
+      </table>
+    )
+  }
+
+  renderCatField (attribute){
+    if (attribute.linked && attribute.linkedWith){
+      return this.renderLinker(attribute)
+    }
+
+    if (attribute.filterSelectedValues.length == 0){
+      return false
+    }
+
+    return form = (
+      <FormGroup>
+        <CustomInput disabled style={{ height: '60px' }} className="attr-select" type="select" multiple>
+          {attribute.filterValues.filter(val => attribute.filterSelectedValues.includes(val.uri)).map(value => {
+            return (<option key={value.uri} selected>{value.label}</option>)
+          })}
+        </CustomInput>
+      </FormGroup>
+    )
+  }
+
+  renderNumField(attribute){
+    if (attribute.linked && attribute.linkedWith){
+      return this.renderLinker(attribute)
+    }
+
+    if (attribute.filters.length == 0){
+      return false
+    }
+
+    let sign_display = {
+      '=': '=',
+      '<': '<',
+      '<=': '≤',
+      '>': '>',
+      '>=': '≥',
+      '!=': '≠'
+    }
+
+    return form = (
+      <table style={{ width: '100%' }}>
+      {attribute.filters.map((filter, index) => {
+        return (
+          <tr key={index}>
+            <td key={index}>
+              <CustomInput key={index} data-index={index} disabled type="select" id={attribute.id}}>
+                  <option selected>{sign_display[filter.filterSign]}</option>
+              </CustomInput>
+            </td>
+              <td>
+              <CustomInput disabled value={filter.filterValue}/>
+              </td>
+          </tr>
+        )
+      })}
+      </table>
+    )
+  }
+
+  attrOverview(attribute){
+    let icons = this.renderIcons(attribute)
+    let form
+    if (attribute.type == 'text' || attribute.type == 'uri') {
+      form = this.renderText()
+    }
+    if (attribute.type == 'decimal' || attribute.type == 'date') {
+      box = this.renderNumeric()
+    }
+    if (attribute.type == 'category' || attribute.type == 'boolean') {
+      box = this.renderCategory()
+    }
+
+    if (!(form && icons)){
+      return
+    }
+
+    return (
+      <div className="attribute-box">
+        <label className="attr-label">{attribute.label}</label>
+        {icons}
+        {form}
+      </div>
+    )
+  }
+
+  renderOverview(){
+    // Iterate on attribute, store it as nodeiD = list of attr to string
+    // Need to store "Options" and "Filters"
+    // Then get the related Nodes names
+    let data = this.props.graphState.attributes.map(attr => this.attrOverview(attr)).filter(attr => attr);
+    return data
+  }
+
+  render () {
+    return(
+      <div>
+        <Modal isOpen={this.state.modal} toggle={this.toggleModal}>
+          <ModalHeader toggle={this.toggleModal}>Query overview</ModalHeader>
+          <ModalBody>
+            {this.renderOverview()}
+          </ModalBody>
+          <ModalFooter>
+            <Button color="secondary" onClick={this.toggleModal}>Close</Button>
+          </ModalFooter>
+        </Modal>
+      </div>
+    )
+  }
+}
+
+OverviewModal.propTypes = {
+  graphState: PropTypes.object
+}

--- a/askomics/react/src/routes/query/query.jsx
+++ b/askomics/react/src/routes/query/query.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import axios from 'axios'
-import { Alert, Button, CustomInput, Row, Col, ButtonGroup, Input, Spinner } from 'reactstrap'
+import { Alert, Button, CustomInput, Row, Col, ButtonGroup, Input, Spinner, ButtonToolbar } from 'reactstrap'
 import { Redirect } from 'react-router-dom'
 import ErrorDiv from '../error/error'
 import WaitingDiv from '../../components/waiting'
@@ -10,6 +10,7 @@ import Visualization from './visualization'
 import AttributeBox from './attribute'
 import LinkView from './linkview'
 import OntoLinkView from './ontolinkview'
+import OverviewModal from './overviewModal'
 import GraphFilters from './graphfilters'
 import ResultsTable from '../sparql/resultstable'
 import PropTypes from 'prop-types'
@@ -1524,6 +1525,7 @@ export default class Query extends Component {
     let isOnto
     let linkView
     let previewButton
+    let overviewButton
     let faldoButton
     let launchQueryButton
     let removeButton
@@ -1630,6 +1632,8 @@ export default class Query extends Component {
       )
 
       // buttons
+      overviewButton = (<OverviewModal divHeight={this.divHeight} graphState={this.state.graphState} handleNodeSelection={p => this.handleNodeSelection(p)} handleLinkSelection={p => this.handleLinkSelection(p)}/>)
+
       let previewIcon = <i className={"fas fa-" + this.state.previewIcon}></i>
       if (this.state.previewIcon == "spinner") {
         previewIcon = <Spinner size="sm" color="light" />
@@ -1707,10 +1711,19 @@ export default class Query extends Component {
           </Col>
         </Row>
         {warningDiskSpace}
-        <ButtonGroup>
-          {previewButton}
-          {launchQueryButton}
-        </ButtonGroup>
+        <Row>
+          <Col xs="7" style={{ paddingRight: 0 }}>
+            <ButtonToolbar className="justify-content-between">
+              <ButtonGroup>
+                {previewButton}
+                {launchQueryButton}
+              </ButtonGroup>
+              <ButtonGroup>
+                {overviewButton}
+              </ButtonGroup>
+            </ButtonToolbar>
+          </Col>
+        </Row>
         <br /> <br />
         <div>
           {resultsTable}

--- a/askomics/static/css/askomics.css
+++ b/askomics/static/css/askomics.css
@@ -141,6 +141,14 @@ div.attribute-box {
   color: #454545;
 }
 
+div.entity-box {
+  margin: 5px;
+  padding: 5px;
+  border-radius: 10px;
+  border: 1px solid #c5c5c5;
+  font-weight: normal;
+}
+
 label.attr-label {
   font-weight: 700;
 }


### PR DESCRIPTION
Should close #388 and close #380 

Overview modal should show all 'selected' attributes (either by using one of the icons, or using a filter).
It will also show entities linked using a faldo/ontological relation

Users will be able to directly select the node.