### PR TITLE
Force 'POST' method instead of 'GET' for queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This changelog was started for release 4.2.0.
 - Increased Galaxy timeout for tests
 - Fix documentation build
 - Force all 'user queries'(ask/sparql interfaces) to go to the unauthenticated endpoint, to increase security (no write permissions)
+- Force all queries to use 'POST' instead of 'GET' to avoid max length issues
 
 ### Security
 

--- a/askomics/libaskomics/SparqlQueryLauncher.py
+++ b/askomics/libaskomics/SparqlQueryLauncher.py
@@ -307,8 +307,8 @@ class SparqlQueryLauncher(Params):
 
             else:
                 # Update
+                self.endpoint.setMethod('POST')
                 if is_update:
-                    self.endpoint.setMethod('POST')
                     # Force sending to secure endpoint
                     self.endpoint.queryType = "INSERT"
                     results = self.endpoint.query()


### PR DESCRIPTION
Should close #325 